### PR TITLE
release: v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Planned
+- SignPath signing integration for Windows artefacts.
+- Light-theme palette follow-up adjustments based on tester feedback.
+
+## [0.1.5] - 2025-10-17
 ### Added
 - Theme picker with Soft Light, Slate, and High Contrast Dark presets.
 - Hash copy button now includes the algorithm prefix (e.g. `SHA256:abcdef…`).
@@ -14,16 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal release checklist recorded to prevent empty/tag-only releases.
 - Structured logging toggle for CLI runs via `--log-format` (text/json).
 - Criterion benchmarks for hashing (1/10/50 MB files across SHA-2/BLAKE2 families).
+- Guidance for using the `skip-linux-ci` label so documentation-only PRs can bypass the Linux job safely.
 
 ### Changed
 - Release workflow trims GitHub assets to installers/portable packages and a single SHA256SUMS manifest.
 - Soft Light palette softened to reduce glare; Slate palette tuned for better contrast.
 - README Feature Highlights updated for theme/copy improvements.
 - Refreshed GUI screenshots (Slate default, algorithm dropdown, match/mismatch, high contrast) in README and docs.
-
-### Planned
-- SignPath signing integration for Windows artefacts.
-- Light-theme palette follow-up adjustments based on tester feedback.
+- CLI terminal detection now relies on `std::io::IsTerminal`, removing the unmaintained `atty` dependency and clearing `cargo audit` warnings.
 
 ## [0.1.4] - 2025-10-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ make rust-gui-smoke-host
 ```
 
 ## CLI Logging Modes
-- Theo mặc định, CLI chỉ in kết quả kiểm tra. Khi cần theo dõi tiến trình hoặc tích hợp hệ thống log, bật structured logging qua `--log-format`:
+- By default the CLI only prints the verification outcome. Enable structured logging with `--log-format` when you need progress information or want to ingest logs elsewhere:
 
 ```bash
-hash-checker path/to/file.txt EXPECTED_HASH --log-format text   # log dạng text
-hash-checker path/to/file.txt EXPECTED_HASH --log-format json   # log dạng JSON
+hash-checker path/to/file.txt EXPECTED_HASH --log-format text   # human-readable logs
+hash-checker path/to/file.txt EXPECTED_HASH --log-format json   # JSON logs
 ```
 
-- Log được ghi ra `stderr`, còn `stdout` giữ nguyên thông báo kết quả nên các script/CI cũ không bị ảnh hưởng.
+- Logs are written to `stderr` so `stdout` keeps the check result unchanged for legacy scripts/CI pipelines.
 
 ## Benchmark
 - Sử dụng Criterion để theo dõi hiệu năng hashing:
@@ -143,7 +143,7 @@ xattr -d com.apple.quarantine "/Applications/Hash Checker.app"
 This guidance will be updated once SignPath signing or notarisation is available.
 
 ## Release & Changelog
-- Latest release: **[v0.1.4](https://github.com/tamld/hash-checker/releases/tag/v0.1.4)** – ships the first universal macOS DMG, aligns crate versions, and publishes packaging evidence (logs and checksums).
+- Latest release: **[v0.1.5](https://github.com/tamld/hash-checker/releases/tag/v0.1.5)** – refreshes GUI themes/copy workflow, adds CLI structured logging, and replaces the unmaintained `atty` crate.
 - Previous releases are listed on the [GitHub Releases](https://github.com/tamld/hash-checker/releases) page. Follow the checklist in `docs/OPERATIONS.md` for release readiness.
 - A structured changelog will be introduced in future releases; for now, consult the release notes for key highlights and verification steps.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -9,7 +9,9 @@ only highlights the key signals and where to dig deeper.
 ## Snapshot
 - GUI polish landed on `main` (theme presets, prefixed hash copy); QA log for the refreshed screenshots is stored under `logs/qa/theme-copy-verification-20251015.md`, and assets were updated again on 2025-10-16.
 - Release automation now builds and verifies the macOS universal DMG inside `release.yml`; the local script remains available for manual runs.
-- Linux CI job now runs on pushes and pull requests again; keep using `workflow_dispatch` inputs for targeted reruns when necessary.
+- Linux CI job now runs on pushes and pull requests again; use the `skip-linux-ci` label only for doc-only PRs per the updated guardrail in `docs/OPERATIONS.md`.
+- CLI no longer depends on the unmaintained `atty` crate; terminal detection now uses `std::io::IsTerminal`, keeping `cargo audit` clean.
+- Release v0.1.5 (2025-10-17) captures the guardrail updates, CLI logging improvements, and dependency refresh.
 - SignPath onboarding remains blocked on OSS subscription; track progress in `.agents/project_state.yml` and `docs/security/SIGNPATH_CHECKLIST.md`.
 - Vagrant smoke validation still requires a VMware-capable host; follow `docs/vagrant/VALIDATION_PLAYBOOK.md` when the hardware window opens.
 

--- a/rust/hash-checker-gui/Cargo.lock
+++ b/rust/hash-checker-gui/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.3"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.40"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstream",
  "anstyle",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "clipboard-win"
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flate2"
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -905,24 +905,24 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.2",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "hash-checker"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "blake2",
  "clap",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "hash-checker-gui"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "assert_cmd",
  "eframe",
@@ -1348,9 +1348,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
@@ -1486,7 +1486,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -1949,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 
 [[package]]
 name = "rfd"
@@ -2195,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2524,15 +2524,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
 
 [[package]]
 name = "wasip2"

--- a/rust/hash-checker-gui/Cargo.toml
+++ b/rust/hash-checker-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-checker-gui"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["tamld <tamld@users.noreply.github.com>"]
 description = "egui-based desktop interface for the Hash Checker tool."

--- a/rust/hash-checker/Cargo.lock
+++ b/rust/hash-checker/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ciborium"
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstream",
  "anstyle",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -367,14 +367,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
 ]
 
 [[package]]
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "hash-checker"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "assert_cmd",
  "blake2",
@@ -476,9 +476,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "linux-raw-sys"
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustix"
@@ -970,15 +970,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
 ]
 
 [[package]]

--- a/rust/hash-checker/Cargo.toml
+++ b/rust/hash-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hash-checker"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["tamld <tamld@users.noreply.github.com>"]
 description = "Cross-platform hash verification utility implemented in Rust."


### PR DESCRIPTION
## Summary
- bump crate versions to 0.1.5 and move changelog entries into the release section
- document the new CI guardrail and README release reference
- refresh lockfiles after dependency updates

## Testing
- make ci-linux-local
- cargo run --release --manifest-path rust/hash-checker-gui/Cargo.toml -- --smoke-test
- cargo audit --file rust/hash-checker/Cargo.lock
- cargo audit --file rust/hash-checker-gui/Cargo.lock