### PR TITLE
docs: slim README and expand operations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,208 +3,39 @@
 [![CI](https://github.com/tamld/hash-checker/actions/workflows/ci.yml/badge.svg)](https://github.com/tamld/hash-checker/actions/workflows/ci.yml)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
 ![Rust](https://img.shields.io/badge/Rust-1.83%2B-orange?logo=rust)
-![Platforms](https://img.shields.io/badge/platforms-Windows%20%7C%20macOS%20%7C%20Linux-4c1)
 
 > Cross-platform integrity checker with a shared Rust core powering CLI and egui desktop apps.
 
-## Table of Contents
-- [Overview](#overview)
-- [Feature Highlights](#feature-highlights)
-- [Clone & Workspace Setup](#clone--workspace-setup)
-- [Quick Start (Containerised)](#quick-start-containerised)
-- [Manual Host Build](#manual-host-build)
-- [Installer Builds](#installer-builds)
-- [Verify Downloads](#verify-downloads)
-- [Release & Changelog](#release--changelog)
-- [Temporary Artefacts](#temporary-artefacts)
-- [Continuous Integration](#continuous-integration)
-- [Project Documents](#project-documents)
-
-## Overview
-Hash Checker delivers reproducible, container-friendly workflows for validating file hashes across Windows, macOS, and Linux. The project is fully Rust-based and uses Docker/Vagrant helpers to keep host systems clean.
-
-## GUI Preview
 ![Hash Checker Slate theme](docs/assets/gui-main.png)
-*Slate theme (default) with copy-to-clipboard shortcut and status banner.*
 
-Key interface states:
+Hash Checker delivers reproducible workflows for validating file hashes on Windows, macOS, and Linux. The project emphasises clean builds (Docker/Vagrant helpers) and an accessible GUI that mirrors the CLI feature set.
 
-![Algorithm dropdown auto-selected from prefix](docs/assets/gui-algorithm.png)
-![Successful verification state](docs/assets/gui-match.png)
-![Verification mismatch warning](docs/assets/gui-mismatch.png)
-![High Contrast mode](docs/assets/gui-high-contrast.png)
-![Folder Scan with manifest summary](docs/assets/gui-folder-scan.png)
-![Directory manifest details dialog](docs/assets/gui-folder-details.png)
+## Highlights
+- Supports SHA-2, SHA-1, MD5, and BLAKE2 families with automatic algorithm detection from hash prefixes.
+- Shared Rust core exposes both command-line and egui desktop interfaces.
+- Directory manifest export/verify with JSON, CSV, and TXT outputs.
+- Container-first `make` targets keep builds reproducible across platforms, while host builds remain available.
+- Accessibility extras: keyboard shortcuts, clipboard integration, and Slate/High Contrast themes.
 
-*Folder Scan screenshots illustrate a verification run with a deliberately introduced mismatch/missing/extra entry so the warning states are visible; a normal scan stays green until you perform an actual verify.*
+## Getting Started
+- Clone: `git clone https://github.com/tamld/hash-checker.git && cd hash-checker` (agents may work from `local-scripts/hash-checker/` inside the workspace layout).
+- Container workflow: `make rust-test`, `make rust-gui-build`, `make rust-gui-smoke`, and `make cleanup-packaging`. See `docs/OPERATIONS.md` for the full command matrix.
+- Host build: `cargo build --release --manifest-path rust/hash-checker/Cargo.toml` plus the GUI variant (`rust/hash-checker-gui/`) or the equivalent `make` targets documented in `docs/OPERATIONS.md`.
+- Local gate: run `make ci-linux-local` before pushing to exercise fmt, clippy, tests, and Docker workflows.
 
-> Screenshot update workflow is documented in `docs/GUI_SCREENSHOT.md`.
+## Documentation
+- `docs/OPERATIONS.md` – quick start, build/packaging commands, CI modes, Gatekeeper notes.
+- `docs/PLAN.md` – roadmap and phase status.
+- `docs/TASKS.md` – near-term work queue.
+- `docs/BACKLOG.md` – longer-term ideas.
+- `docs/security/VERIFICATION_GUIDE.md` – checksum, GPG, and Authenticode verification.
+- `docs/GUI_SCREENSHOT.md` – screenshot checklist and gallery.
 
-## Feature Highlights
-- Multiple algorithms: SHA-2 family, SHA-1, MD5, BLAKE2.
-- Automatic algorithm detection based on digest length.
-- Command-line and egui desktop interfaces sharing the same Rust core.
-- Container-first workflows (Docker/Vagrant) to avoid host pollution.
-- Built-in clipboard workflow (copy computed hashes) and accessibility toggles for the GUI.
-- Theme picker for the GUI (Soft Light, Slate, High Contrast Dark).
-- Warns when pasted hashes use unsupported prefixes so users can correct them before verification.
-- Copy/paste aware hash comparison: copy buttons include algorithm prefixes and pasting prefixed values auto-selects the algorithm.
+## Verify & Support
+- Stable releases live on the [GitHub Releases page](https://github.com/tamld/hash-checker/releases). Installer and binary packages remain unsigned until SignPath onboarding completes.
+- Follow `docs/security/VERIFICATION_GUIDE.md` to validate downloads; macOS Gatekeeper bypass commands are mirrored in `docs/OPERATIONS.md`.
+- File bugs or feature requests through [GitHub Issues](https://github.com/tamld/hash-checker/issues) and reference the relevant documentation or `.agents/` notes for evidence.
 
-## Clone & Workspace Setup
-```bash
-# Clone the public repository
-git clone https://github.com/tamld/hash-checker.git
-cd hash-checker
-
-# (Optional) work inside the assistant workspace layout
-cd local-scripts/hash-checker
-```
-> Note: all scripts/Make targets assume you are inside the repository folder (`hash-checker/` or `local-scripts/hash-checker/`). Update your own remote/fork if you are contributing from a fork.
-
-## Quick Start (Containerised)
-Prerequisites: Docker (build/test) and Vagrant + VMware Fusion (optional, for headless GUI smoke tests).
-
-| Command | Purpose |
-| --- | --- |
-| `make rust-test` | Run Rust CLI unit/integration tests inside Docker |
-| `make rust-build` | Build Rust CLI release binary in Docker |
-| `make rust-gui-build` | Build Rust GUI release binary in Docker (installs GTK) |
-| `make rust-gui-smoke` | Launch Vagrant VM and run `cargo run -- --smoke-test` |
-| `make rust-build-temp` | Build CLI+GUI in Docker and copy artefacts to `/tmp/hash-checker-build` |
-| `make clean` | Remove build artefacts and prune Docker volumes |
-| `make cleanup-packaging` | Remove packaging staging directories (`dist/linux`, `target/packager`, `/tmp/hash-checker-*`) |
-
-> Tip: keep build outputs out of the repo workspace—set `CARGO_TARGET_DIR` to an OS-specific temp path (for example `/tmp/hash-checker-target` on Linux/macOS or `%TEMP%\hash-checker-target` on Windows) before running Docker/host builds so sync tools do not lock intermediate files, and delete that temp directory or run `make clean` once finished.
-
-## Manual Host Build
-Prefer building locally? With Rust installed:
-
-```bash
-# CLI
-cargo build --release --manifest-path rust/hash-checker/Cargo.toml
-
-# GUI (ensure system GTK deps on Linux/macOS)
-cargo build --release --manifest-path rust/hash-checker-gui/Cargo.toml
-cargo run --release --manifest-path rust/hash-checker-gui/Cargo.toml -- --smoke-test
-```
-
-Equivalent Make targets:
-```bash
-make rust-build-host
-make rust-gui-build-host
-make rust-gui-smoke-host
-```
-
-## CLI Logging Modes
-- By default the CLI only prints the verification outcome. Enable structured logging with `--log-format` when you need progress information or want to ingest logs elsewhere:
-
-```bash
-hash-checker path/to/file.txt EXPECTED_HASH --log-format text   # human-readable logs
-hash-checker path/to/file.txt EXPECTED_HASH --log-format json   # JSON logs
-```
-
-- Logs are written to `stderr` so `stdout` keeps the check result unchanged for legacy scripts/CI pipelines.
-
-## Directory Manifests (CLI)
-- Export a directory manifest (JSON by default, SHA-256 hashes, include subdirectories with `-r`):
-
-```bash
-hash-checker manifest export /path/to/folder -o folder.manifest.json -r
-```
-
-- Verify a manifest (format auto-detected from extension):
-
-```bash
-hash-checker manifest verify folder.manifest.json
-```
-
-- Handy flags:
-  - `--format csv|txt` to switch output format.
-  - `--algorithm sha512` to change the hashing algorithm.
-  - `--root /mnt/data` if verifying from a different directory than the one recorded.
-  - `--report-limit 5` to cap the mismatch/missing summary output.
-
-## Benchmark
-- Sử dụng Criterion để theo dõi hiệu năng hashing:
-
-```bash
-cargo bench --manifest-path rust/hash-checker/Cargo.toml
-```
-
-- Benchmarks tạo dữ liệu 1/10/50 MB và đo SHA-256, SHA-512, BLAKE2s, BLAKE2b. Kết quả nằm trong `target/criterion/` (có HTML, CSV) để so sánh giữa các commit.
-
-## Installer Builds
-- Install the packager once per machine: `cargo install cargo-packager@0.11.7 --locked`.
-- From `rust/hash-checker-gui/`, run `cargo packager --release --formats dmg` (macOS) or `cargo packager --release --formats deb appimage pacman` (Linux) to produce native installers.
-- Windows CI publishes both the portable `hash-checker-windows-portable.zip` archive and an NSIS installer executable.
-- Windows packaging consumes the multi-resolution icon at `docs/assets/icon-hash-checker.ico` so the executable/installer display the Hash Checker branding.
-- macOS artefacts are currently unsigned; users can Control-click → **Open** or clear quarantine with `xattr -d com.apple.quarantine "/Applications/Hash Checker.app"`.
-
-## Verify Downloads
-- Each release ships a `SHA256SUMS` file; download it alongside the installer/binary.
-- On macOS/Linux run `shasum -a 256 <artefact>` and compare with the recorded digest (`grep <artefact> SHA256SUMS`).
-- On Windows run `Get-FileHash <artefact> -Algorithm SHA256` or use the CLI binary and the recorded digest.
-- Full command examples for every platform (including upcoming signature validation) live in `docs/security/VERIFICATION_GUIDE.md`.
-- macOS build ships a universal (Intel + Apple Silicon) DMG; see Gatekeeper notes below for unsigned installs.
-- Current status: macOS DMG is unsigned and Windows artefacts remain unsigned while SignPath onboarding is pending. Always verify with the guide above. Hash inputs may include prefixes like `sha256:<digest>`; the app auto-detects the algorithm and updates the dropdown automatically.
-
-### macOS Gatekeeper (Unsigned Build)
-
-Gatekeeper warns when launching an unsigned DMG/app. Follow these steps to run the current release:
-
-1. Download and mount the DMG from the Hash Checker release page.
-2. In Finder, right-click `Hash Checker.app` and choose **Open**.
-3. When the warning dialog appears, click **Open** again to confirm.
-
-To remove the quarantine flag manually (e.g., after copying to `/Applications`):
-
-```bash
-xattr -d com.apple.quarantine "/Applications/Hash Checker.app"
-```
-
-This guidance will be updated once SignPath signing or notarisation is available.
-
-## Release & Changelog
-- Latest release: **[v0.1.5](https://github.com/tamld/hash-checker/releases/tag/v0.1.5)** – refreshes GUI themes/copy workflow, adds CLI structured logging, and replaces the unmaintained `atty` crate.
-- Previous releases are listed on the [GitHub Releases](https://github.com/tamld/hash-checker/releases) page. Follow the checklist in `docs/OPERATIONS.md` for release readiness.
-- A structured changelog will be introduced in future releases; for now, consult the release notes for key highlights and verification steps.
-
-## Temporary Artefacts
-Need binaries quickly without touching the repo tree?
-
-```bash
-make rust-build-temp
-ls /tmp/hash-checker-build
-```
-Produces `hash-checker`, `hash-checker-gui`, and `SHA256SUMS` in `/tmp/hash-checker-build`.
-
-Platform-specific packages can also be generated into temp directories:
-
-```bash
-make rust-gui-dmg-temp        # -> /tmp/hash-checker-gui/*.dmg (macOS)
-make rust-linux-deb-temp      # -> /tmp/hash-checker-deb/*.deb (Linux build from mac host via cargo-packager)
-make rust-windows-zip-temp    # -> ${TMPDIR:-/tmp}/hash-checker-win/hash-checker-windows-portable.zip (use %TEMP%\hash-checker-win on native Windows)
-```
-
-## Continuous Integration
-- `.github/workflows/ci.yml` runs macOS and Windows on every push/PR. Linux is opt-in and should be triggered manually via `gh workflow run` once the local gate passes.
-- Each job now focuses on formatting, linting, unit/smoke tests. Packaging of installers happens only in the release workflow (tags or manual dispatch).
-- Docker helpers ensure build outputs remain accessible between steps.
-- Before pushing, run `make ci-linux-local` to execute fmt/clippy/tests inside a Docker container and store logs under `logs/`.
-- Execute `make deps-refresh` during the monthly maintenance cadence to update dependencies and log security scans.
-- Store any sensitive planning docs under `docs/private/` (ignored by git) so the public repo remains clean.
-
-## Project Documents
-- Roadmap overview: `docs/PLAN.md`
-- Active task tracker: `docs/TASKS.md`
-- Backlog & long-term ideas: `docs/BACKLOG.md`
-- Security strategy: `docs/SECURITY_ROADMAP.md`
-- Threat model summary: `docs/security/THREAT_MODEL.md`
-- Download verification (checksum, GPG, Authenticode): `docs/security/VERIFICATION_GUIDE.md`
-- CI signing integration (SignPath + GPG): `docs/security/CI_SIGNING.md`
-- Release operations & runner strategy: `docs/OPERATIONS.md`
-- Windows signing playbook: `docs/SIGNING.md`
-- Dependency migration plan: `docs/DEPENDENCY_MIGRATION.md`
-- GUI architecture notes: `docs/GUI_DECISION.md`, `docs/GUI_MVP_DESIGN.md`
-- Repo guardrails: `docs/PROJECT_STATUS.md` (public overview). Internal automation notes live in the git-ignored `.agents/` workspace.
-- Contributor behaviour: `CODE_OF_CONDUCT.md`
+## Status
+- `main` is gated by `ci.yml` (fmt, clippy, unit tests, Docker builds, GUI smoke). Packaging jobs run via `release.yml` when preparing artefacts.
+- Internal automation checklists and lessons live under the git-ignored `.agents/` workspace; sync them after every session.

--- a/docs/GUI_SCREENSHOT.md
+++ b/docs/GUI_SCREENSHOT.md
@@ -19,6 +19,20 @@ Goal: provide a consistent set of screenshots for README/docs whenever the GUI c
 | `gui-high-contrast.png` | High contrast mode enabled | Highlight the toggle and dark color scheme |
 | `gui-theme-slate.png` | Theme selector overview | Highlight the Slate/Soft Light/High Contrast selector dialog |
 
+## Reference Gallery (public docs)
+
+These canonical shots power the single hero image in `README.md`. Keep the gallery up to date whenever UI tweaks land so downstream docs stay accurate.
+
+![Hash Checker Slate theme](assets/gui-main.png)
+*Slate theme (default) with copy-to-clipboard shortcut and status banner.*
+
+![Algorithm dropdown auto-selected from prefix](assets/gui-algorithm.png)
+![Successful verification state](assets/gui-match.png)
+![Verification mismatch warning](assets/gui-mismatch.png)
+![High Contrast mode](assets/gui-high-contrast.png)
+![Folder Scan with manifest summary](assets/gui-folder-scan.png)
+![Directory manifest details dialog](assets/gui-folder-details.png)
+
 ## Storage rules
 - Save files in `docs/assets/` and keep the naming as listed above.
 - Update README/docs references if filenames change.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,5 +1,108 @@
 # Operations Guide
 
+## Developer Quick Reference
+
+### Clone & Workspace Layout
+```bash
+# Clone the public repository
+git clone https://github.com/tamld/hash-checker.git
+cd hash-checker
+
+# (Optional) work inside the assistant workspace layout
+cd local-scripts/hash-checker
+```
+
+> Most scripts/Make targets expect you to run them from the repository root (`hash-checker/` or `local-scripts/hash-checker/`). Update the remote when working from a fork.
+
+### Container Quick Start
+Prerequisites: Docker for build/test; Vagrant + VMware Fusion (optional) for headless GUI smoke tests.
+
+| Command | Purpose |
+| --- | --- |
+| `make rust-test` | Run Rust CLI unit/integration tests inside Docker |
+| `make rust-build` | Build Rust CLI release binary in Docker |
+| `make rust-gui-build` | Build Rust GUI release binary in Docker (installs GTK) |
+| `make rust-gui-smoke` | Launch Vagrant VM and run `cargo run -- --smoke-test` |
+| `make rust-build-temp` | Build CLI + GUI in Docker and copy artefacts to `/tmp/hash-checker-build` |
+| `make clean` | Remove build artefacts and prune Docker volumes |
+| `make cleanup-packaging` | Remove packaging staging directories (`dist/linux`, `target/packager`, `/tmp/hash-checker-*`) |
+
+> Recommendation: export `CARGO_TARGET_DIR` to an OS-specific temp path (for example `/tmp/hash-checker-target` or `%TEMP%\hash-checker-target`) so sync tools do not lock intermediate files. Clean up the directory or run `make clean` after finishing.
+
+### Host Builds (Rust Installed)
+```bash
+# CLI
+cargo build --release --manifest-path rust/hash-checker/Cargo.toml
+
+# GUI (ensure system GTK deps on Linux/macOS)
+cargo build --release --manifest-path rust/hash-checker-gui/Cargo.toml
+cargo run --release --manifest-path rust/hash-checker-gui/Cargo.toml -- --smoke-test
+
+# Equivalent Make targets
+make rust-build-host
+make rust-gui-build-host
+make rust-gui-smoke-host
+```
+
+### CLI Logging & Manifests
+- By default the CLI prints only the verification outcome. Use `--log-format text|json` when you need structured progress information; logs write to `stderr` so `stdout` stays script-friendly.
+- Export directory manifests with `hash-checker manifest export <path> -o <file> -r` (JSON default). Verify with `hash-checker manifest verify <file>`.
+- Helpful flags: `--format csv|txt`, `--algorithm <algo>`, `--root <path>` (when verifying from a different base directory), `--report-limit <n>` to cap mismatch summaries.
+
+### Benchmarks
+Run Criterion benchmarks to track hashing performance:
+```bash
+cargo bench --manifest-path rust/hash-checker/Cargo.toml
+```
+Benchmarks generate 1/10/50 MB samples and record SHA-256/512, BLAKE2s/B results in `target/criterion/` (HTML + CSV).
+
+### Installer Builds
+- Install `cargo-packager` once: `cargo install cargo-packager@0.11.7 --locked`.
+- From `rust/hash-checker-gui/` run `cargo packager --release --formats dmg` (macOS) or `cargo packager --release --formats deb appimage pacman` (Linux).
+- Windows CI publishes both the portable ZIP and NSIS installer. Packaging uses `docs/assets/icon-hash-checker.ico` for application branding.
+- macOS artefacts are currently unsigned; see Gatekeeper notes below or in the README.
+
+### Temporary Artefacts & Cleanup
+Use `make rust-build-temp` to stage CLI + GUI binaries under `/tmp/hash-checker-build`. Platform-specific helpers:
+```bash
+make rust-gui-dmg-temp        # -> /tmp/hash-checker-gui/*.dmg (macOS)
+make rust-linux-deb-temp      # -> /tmp/hash-checker-deb/*.deb (Linux build from mac host via cargo-packager)
+make rust-windows-zip-temp    # -> ${TMPDIR:-/tmp}/hash-checker-win/hash-checker-windows-portable.zip (%TEMP% on Windows)
+```
+Follow up with `make cleanup-packaging` to remove staging artefacts.
+
+### Verify Downloads
+- Each release publishes `SHA256SUMS`; download it alongside the artefact and validate with `shasum -a 256`, `Get-FileHash`, or the CLI.
+- For full platform instructions (including GPG and Authenticode verification) follow `docs/security/VERIFICATION_GUIDE.md`.
+- macOS builds remain unsigned; Gatekeeper bypass commands are documented below until notarisation is available.
+
+#### macOS Gatekeeper (Unsigned Builds)
+1. Mount the DMG from the release page.
+2. In Finder, right-click `Hash Checker.app` and choose **Open**.
+3. When the warning dialog appears, click **Open** again to confirm.
+
+Clear the quarantine flag manually after copying to `/Applications`:
+```bash
+xattr -d com.apple.quarantine "/Applications/Hash Checker.app"
+```
+
+### Local CI Gate
+- Run `make ci-linux-local` before pushing to execute fmt, clippy, tests, and Docker workflows.
+- Monthly maintenance: `make deps-refresh` updates dependencies, runs `cargo audit`/`cargo deny`, and refreshes cached toolchains. Capture logs under `logs/`.
+- See **CI Modes (2025-10-19)** for the mapping between local checks and GitHub Actions.
+
+### Documentation Index
+- Roadmap: `docs/PLAN.md`
+- Tasks: `docs/TASKS.md`
+- Backlog: `docs/BACKLOG.md`
+- Security roadmap: `docs/SECURITY_ROADMAP.md`
+- Threat model: `docs/security/THREAT_MODEL.md`
+- Verification guide: `docs/security/VERIFICATION_GUIDE.md`
+- Signing/credential playbooks: `docs/SIGNING.md`, `docs/security/CREDENTIAL_RUNBOOK.md`
+- GUI design: `docs/GUI_DECISION.md`, `docs/GUI_MVP_DESIGN.md`
+- Release operations: this file (`docs/OPERATIONS.md`)
+- Contributor conduct: `CODE_OF_CONDUCT.md`
+
 ## Release Checklist
 1. Ensure CI (`ci.yml`) is green on the target commit.
 2. Confirm the Release Readiness checklist in `docs/PLAN.md` is satisfied.


### PR DESCRIPTION
Fixes #27

## Summary
- Trim README to hero image, highlights, quick start pointers
- Move detailed build/CI/verification guidance into docs/OPERATIONS.md
- Add gallery section to docs/GUI_SCREENSHOT.md so README can stay concise

## Testing
- make ci-linux-local (logs/ci-linux-20251019-233326.log)