### PR TITLE
feat: add batch comparison reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Hash Checker delivers reproducible workflows for validating file hashes on Windo
 ## Highlights
 - Supports SHA-2, SHA-1, MD5, and BLAKE2 families with automatic algorithm detection from hash prefixes.
 - Shared Rust core exposes both command-line and egui desktop interfaces.
+- Batch comparison reports for CI: feed JSON/CSV definitions to `hash-checker batch` and export structured results.
 - Directory manifest export/verify with JSON, CSV, and TXT outputs.
 - Container-first `make` targets keep builds reproducible across platforms, while host builds remain available.
 - Accessibility extras: keyboard shortcuts, clipboard integration, and Slate/High Contrast themes.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -49,6 +49,30 @@ make rust-gui-smoke-host
 - Export directory manifests with `hash-checker manifest export <path> -o <file> -r` (JSON default). Verify with `hash-checker manifest verify <file>`.
 - Helpful flags: `--format csv|txt`, `--algorithm <algo>`, `--root <path>` (when verifying from a different base directory), `--report-limit <n>` to cap mismatch summaries.
 
+### Batch Comparison Reports
+- Define expected hashes in JSON or CSV and feed them to the new batch command:
+
+  ```json
+  [
+    { "path": "dist/hash-checker", "expected": "sha256:<digest>" },
+    { "path": "README.md", "expected": "109788a70f52a60437d3c8867124ca72", "algorithm": "md5" }
+  ]
+  ```
+
+- Generate a report suitable for CI pipelines:
+
+  ```bash
+  hash-checker batch --input hashes.json --output report.json --output-format json
+  # or CSV:
+  hash-checker batch --input hashes.csv --input-format csv --output report.csv --output-format csv
+  ```
+
+- Exit codes mirror manifest verification:
+  - `0` – all entries matched.
+  - `3` – mismatched or missing files detected.
+  - `2` – unrecoverable errors (I/O, unsupported algorithms).
+- Reports contain a summary block plus `entries[]` with `status` (`match`, `mismatch`, `missing`, `error`) and the computed hash when available.
+
 ### Benchmarks
 Run Criterion benchmarks to track hashing performance:
 ```bash

--- a/rust/hash-checker/src/batch.rs
+++ b/rust/hash-checker/src/batch.rs
@@ -1,0 +1,176 @@
+use crate::{detect_algorithm, verify_hash, HashError};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BatchInput {
+    pub path: PathBuf,
+    pub expected: String,
+    #[serde(default)]
+    pub algorithm: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchSummary {
+    pub total: usize,
+    pub matched: usize,
+    pub mismatched: usize,
+    pub missing: usize,
+    pub errored: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchEntry {
+    pub path: String,
+    pub status: BatchStatus,
+    pub expected: String,
+    pub actual: Option<String>,
+    pub algorithm: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchStatus {
+    Match,
+    Mismatch,
+    Missing,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BatchReport {
+    pub summary: BatchSummary,
+    pub entries: Vec<BatchEntry>,
+}
+
+impl BatchReport {
+    pub fn exit_code(&self) -> i32 {
+        if self.summary.errored > 0 {
+            2
+        } else if self.summary.mismatched > 0 || self.summary.missing > 0 {
+            3
+        } else {
+            0
+        }
+    }
+}
+
+pub fn run_batch(inputs: &[BatchInput]) -> BatchReport {
+    let mut entries = Vec::with_capacity(inputs.len());
+    let mut matched = 0usize;
+    let mut mismatched = 0usize;
+    let mut missing = 0usize;
+    let mut errored = 0usize;
+
+    for input in inputs {
+        let algorithm_hint = algorithm_hint(input);
+        let path = input.path.clone();
+        let path_display = path.display().to_string();
+        let expected = input.expected.trim().to_string();
+
+        match verify_file(&path, &expected, input.algorithm.as_deref()) {
+            Ok((BatchStatus::Match, actual)) => {
+                matched += 1;
+                entries.push(BatchEntry {
+                    path: path_display,
+                    status: BatchStatus::Match,
+                    expected: expected.clone(),
+                    actual: Some(actual),
+                    algorithm: algorithm_hint,
+                    error: None,
+                });
+            }
+            Ok((BatchStatus::Mismatch, actual)) => {
+                mismatched += 1;
+                entries.push(BatchEntry {
+                    path: path_display,
+                    status: BatchStatus::Mismatch,
+                    expected: expected.clone(),
+                    actual: Some(actual),
+                    algorithm: algorithm_hint,
+                    error: None,
+                });
+            }
+            Ok((BatchStatus::Missing, _)) | Ok((BatchStatus::Error, _)) => {
+                unreachable!("verify_file does not return missing/error statuses");
+            }
+            Err(err) => {
+                let (status, err_msg) = map_error(&err);
+                match status {
+                    BatchStatus::Missing => missing += 1,
+                    BatchStatus::Error => errored += 1,
+                    _ => {}
+                }
+                entries.push(BatchEntry {
+                    path: path_display,
+                    status,
+                    expected,
+                    actual: None,
+                    algorithm: algorithm_hint,
+                    error: Some(err_msg),
+                });
+            }
+        }
+    }
+
+    let summary = BatchSummary {
+        total: inputs.len(),
+        matched,
+        mismatched,
+        missing,
+        errored,
+    };
+
+    BatchReport { summary, entries }
+}
+
+fn algorithm_hint(input: &BatchInput) -> Option<String> {
+    if let Some(alg) = input
+        .algorithm
+        .as_ref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+    {
+        return Some(alg.to_ascii_lowercase());
+    }
+    detect_algorithm(&input.expected).map(|alg| alg.to_string())
+}
+
+fn verify_file(
+    path: &Path,
+    expected: &str,
+    algorithm: Option<&str>,
+) -> Result<(BatchStatus, String), HashError> {
+    match verify_hash(path, expected, algorithm) {
+        Ok((true, computed)) => Ok((BatchStatus::Match, computed)),
+        Ok((false, computed)) => Ok((BatchStatus::Mismatch, computed)),
+        Err(err) => Err(err),
+    }
+}
+
+fn map_error(err: &HashError) -> (BatchStatus, String) {
+    match err {
+        HashError::PathNotFound(_) => (BatchStatus::Missing, err.to_string()),
+        HashError::NotAFile(_) => (BatchStatus::Error, err.to_string()),
+        HashError::UnsupportedAlgorithm(_) => (BatchStatus::Error, err.to_string()),
+        HashError::InferenceFailed(_) => (BatchStatus::Error, err.to_string()),
+        HashError::InvalidExpectedHash => (BatchStatus::Error, err.to_string()),
+        HashError::EmptyExpectedHash => (BatchStatus::Error, err.to_string()),
+        HashError::Canonicalize { source, .. } => {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                (BatchStatus::Missing, err.to_string())
+            } else {
+                (BatchStatus::Error, err.to_string())
+            }
+        }
+        HashError::Io(io_err) => {
+            if io_err.kind() == std::io::ErrorKind::NotFound {
+                (BatchStatus::Missing, err.to_string())
+            } else {
+                (BatchStatus::Error, err.to_string())
+            }
+        }
+        _ => (BatchStatus::Error, err.to_string()),
+    }
+}

--- a/rust/hash-checker/src/lib.rs
+++ b/rust/hash-checker/src/lib.rs
@@ -4,8 +4,10 @@ use std::{
     path::Path,
 };
 
+mod batch;
 mod manifest;
 
+pub use batch::{run_batch, BatchEntry, BatchInput, BatchReport, BatchStatus, BatchSummary};
 pub use manifest::{
     apply_entry_path, detect_format_from_extension, generate_manifest, read_manifest,
     relative_path_string, resolve_root, verify_manifest, write_manifest, Manifest, ManifestEntry,

--- a/rust/hash-checker/src/main.rs
+++ b/rust/hash-checker/src/main.rs
@@ -1,14 +1,16 @@
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::io::{stderr, IsTerminal};
 use std::path::{Path, PathBuf};
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use hash_checker::{
     detect_format_from_extension, generate_manifest, read_manifest, relative_path_string,
-    resolve_root, supported_algorithms, verify_hash, verify_manifest, write_manifest, HashResult,
-    ManifestFormat, VerificationReport,
+    resolve_root, run_batch, supported_algorithms, verify_hash, verify_manifest, write_manifest,
+    BatchInput, BatchReport, BatchStatus, HashError, HashResult, ManifestFormat,
+    VerificationReport,
 };
+use serde::Deserialize;
 use tracing::{error, info, warn};
 
 #[derive(Parser, Debug)]
@@ -55,6 +57,7 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     Manifest(ManifestCommand),
+    Batch(BatchArgs),
 }
 
 #[derive(Args, Debug)]
@@ -67,6 +70,39 @@ struct ManifestCommand {
 enum ManifestAction {
     Export(ManifestExportArgs),
     Verify(ManifestVerifyArgs),
+}
+
+#[derive(Args, Debug)]
+struct BatchArgs {
+    #[arg(
+        long = "input",
+        value_name = "PATH",
+        help = "Input file containing batch entries (JSON or CSV). Use '-' or omit to read from stdin."
+    )]
+    input: Option<PathBuf>,
+
+    #[arg(
+        long = "input-format",
+        value_enum,
+        default_value_t = BatchFormatArg::Json,
+        help = "Format of the input definition."
+    )]
+    input_format: BatchFormatArg,
+
+    #[arg(
+        long = "output",
+        value_name = "PATH",
+        help = "Write report to file instead of stdout."
+    )]
+    output: Option<PathBuf>,
+
+    #[arg(
+        long = "output-format",
+        value_enum,
+        default_value_t = BatchFormatArg::Json,
+        help = "Format of the generated report."
+    )]
+    output_format: BatchFormatArg,
 }
 
 #[derive(Args, Debug)]
@@ -114,6 +150,12 @@ enum ManifestFormatArg {
     Json,
     Csv,
     Txt,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
+enum BatchFormatArg {
+    Json,
+    Csv,
 }
 
 impl ManifestFormatArg {
@@ -232,6 +274,7 @@ fn init_logging(format: LogFormat) {
 fn handle_command(command: Commands) -> HashResult<i32> {
     match command {
         Commands::Manifest(manifest) => handle_manifest_command(manifest),
+        Commands::Batch(args) => handle_batch_command(args),
     }
 }
 
@@ -243,6 +286,27 @@ fn handle_manifest_command(manifest: ManifestCommand) -> HashResult<i32> {
         }
         ManifestAction::Verify(args) => handle_manifest_verify(args),
     }
+}
+
+fn handle_batch_command(args: BatchArgs) -> HashResult<i32> {
+    let inputs = read_batch_inputs(&args)?;
+    if inputs.is_empty() {
+        return Err(HashError::ManifestParse(
+            "batch input is empty; provide at least one entry".to_string(),
+        ));
+    }
+
+    let report = run_batch(&inputs);
+    write_batch_report(&report, &args)?;
+    eprintln!(
+        "Batch summary: matched={}, mismatched={}, missing={}, errored={}",
+        report.summary.matched,
+        report.summary.mismatched,
+        report.summary.missing,
+        report.summary.errored
+    );
+
+    Ok(report.exit_code())
 }
 
 fn handle_manifest_export(args: ManifestExportArgs) -> HashResult<()> {
@@ -362,4 +426,150 @@ fn manifest_relative_to_root(manifest_path: &Path, root: &Path) -> Option<String
         .strip_prefix(root_canonical)
         .ok()
         .map(relative_path_string)
+}
+
+fn read_batch_inputs(args: &BatchArgs) -> HashResult<Vec<BatchInput>> {
+    let read_from_stdin = args
+        .input
+        .as_ref()
+        .map(|path| path == Path::new("-"))
+        .unwrap_or(args.input.is_none());
+
+    if read_from_stdin {
+        let stdin = io::stdin();
+        let handle = stdin.lock();
+        read_batch_inputs_from_reader(handle, args.input_format)
+    } else {
+        let path = args.input.as_ref().expect("input path present");
+        let file = File::open(path)?;
+        read_batch_inputs_from_reader(file, args.input_format)
+    }
+}
+
+fn read_batch_inputs_from_reader<R: Read>(
+    reader: R,
+    format: BatchFormatArg,
+) -> HashResult<Vec<BatchInput>> {
+    match format {
+        BatchFormatArg::Json => {
+            serde_json::from_reader(reader).map_err(|err| HashError::ManifestParse(err.to_string()))
+        }
+        BatchFormatArg::Csv => {
+            let mut rdr = csv::ReaderBuilder::new()
+                .trim(csv::Trim::All)
+                .from_reader(reader);
+
+            let mut inputs = Vec::new();
+            for row in rdr.deserialize::<CsvBatchRow>() {
+                let record: CsvBatchRow =
+                    row.map_err(|err| HashError::ManifestParse(err.to_string()))?;
+                inputs.push(BatchInput {
+                    path: PathBuf::from(record.path),
+                    expected: record.expected,
+                    algorithm: record.algorithm,
+                });
+            }
+            Ok(inputs)
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CsvBatchRow {
+    path: String,
+    expected: String,
+    #[serde(default)]
+    algorithm: Option<String>,
+}
+
+fn write_batch_report(report: &BatchReport, args: &BatchArgs) -> HashResult<()> {
+    match args.output_format {
+        BatchFormatArg::Json => {
+            if let Some(path) = &args.output {
+                let file = File::create(path)?;
+                serde_json::to_writer_pretty(file, report)
+                    .map_err(|err| HashError::ManifestSerialize(err.to_string()))?;
+            } else {
+                let stdout = io::stdout();
+                let mut handle = stdout.lock();
+                serde_json::to_writer_pretty(&mut handle, report)
+                    .map_err(|err| HashError::ManifestSerialize(err.to_string()))?;
+                handle.write_all(b"\n")?;
+            }
+        }
+        BatchFormatArg::Csv => {
+            let write_target = match &args.output {
+                Some(path) => {
+                    let file = File::create(path)?;
+                    EitherWriter::File(file)
+                }
+                None => {
+                    let stdout = io::stdout();
+                    EitherWriter::Stdout(stdout)
+                }
+            };
+            write_batch_report_csv(report, write_target)?;
+        }
+    }
+    Ok(())
+}
+
+enum EitherWriter {
+    File(File),
+    Stdout(io::Stdout),
+}
+
+impl Write for EitherWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            EitherWriter::File(file) => file.write(buf),
+            EitherWriter::Stdout(stdout) => {
+                let mut handle = stdout.lock();
+                handle.write(buf)
+            }
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            EitherWriter::File(file) => file.flush(),
+            EitherWriter::Stdout(stdout) => {
+                let mut handle = stdout.lock();
+                handle.flush()
+            }
+        }
+    }
+}
+
+fn write_batch_report_csv(report: &BatchReport, mut writer: EitherWriter) -> HashResult<()> {
+    let mut wtr = csv::WriterBuilder::new()
+        .has_headers(true)
+        .from_writer(&mut writer);
+
+    wtr.write_record(["path", "status", "expected", "actual", "algorithm", "error"])
+        .map_err(|err| HashError::ManifestSerialize(err.to_string()))?;
+
+    for entry in &report.entries {
+        let status = match entry.status {
+            BatchStatus::Match => "match",
+            BatchStatus::Mismatch => "mismatch",
+            BatchStatus::Missing => "missing",
+            BatchStatus::Error => "error",
+        };
+        wtr.write_record([
+            entry.path.as_str(),
+            status,
+            entry.expected.as_str(),
+            entry.actual.as_deref().unwrap_or(""),
+            entry.algorithm.as_deref().unwrap_or(""),
+            entry.error.as_deref().unwrap_or(""),
+        ])
+        .map_err(|err| HashError::ManifestSerialize(err.to_string()))?;
+    }
+
+    wtr.flush()
+        .map_err(|err| HashError::ManifestSerialize(err.to_string()))?;
+    drop(wtr);
+    writer.flush()?;
+    Ok(())
 }

--- a/rust/hash-checker/tests/batch_reports.rs
+++ b/rust/hash-checker/tests/batch_reports.rs
@@ -1,0 +1,78 @@
+use assert_cmd::Command;
+use hash_checker::{compute_hash, run_batch, BatchInput, BatchStatus};
+use serde_json::json;
+use std::fs::File;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn write_temp_file(contents: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::new().expect("temp file");
+    file.write_all(contents.as_bytes()).expect("write");
+    file
+}
+
+#[test]
+fn run_batch_reports_match_and_mismatch() {
+    let file_ok = write_temp_file("ok");
+    let file_bad = write_temp_file("bad");
+
+    let expected_ok = compute_hash(file_ok.path(), "sha256").expect("hash");
+    let wrong_hash = "f".repeat(64);
+
+    let inputs = vec![
+        BatchInput {
+            path: file_ok.path().to_path_buf(),
+            expected: expected_ok.clone(),
+            algorithm: Some("sha256".into()),
+        },
+        BatchInput {
+            path: file_bad.path().to_path_buf(),
+            expected: wrong_hash.clone(),
+            algorithm: Some("sha256".into()),
+        },
+        BatchInput {
+            path: file_bad.path().parent().unwrap().join("missing.txt"),
+            expected: wrong_hash,
+            algorithm: None,
+        },
+    ];
+
+    let report = run_batch(&inputs);
+    assert_eq!(report.summary.total, 3);
+    assert_eq!(report.summary.matched, 1);
+    assert_eq!(report.summary.mismatched, 1);
+    assert_eq!(report.summary.missing, 1);
+    assert_eq!(report.summary.errored, 0);
+
+    let statuses: Vec<BatchStatus> = report.entries.iter().map(|e| e.status.clone()).collect();
+    assert!(statuses.contains(&BatchStatus::Match));
+    assert!(statuses.contains(&BatchStatus::Mismatch));
+    assert!(statuses.contains(&BatchStatus::Missing));
+}
+
+#[test]
+fn cli_batch_outputs_json() {
+    let file_ok = write_temp_file("hash-checker");
+    let digest = compute_hash(file_ok.path(), "sha256").expect("hash");
+
+    let tmp = NamedTempFile::new().expect("temp input");
+    let payload = json!([{
+        "path": file_ok.path().display().to_string(),
+        "expected": digest,
+        "algorithm": "sha256"
+    }]);
+    serde_json::to_writer(&File::create(tmp.path()).expect("create input"), &payload)
+        .expect("write json");
+
+    let mut cmd = Command::cargo_bin("hash-checker").expect("binary");
+    cmd.args([
+        "batch",
+        "--input",
+        tmp.path().to_str().unwrap(),
+        "--output-format",
+        "json",
+    ]);
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("\"matched\": 1"));
+}


### PR DESCRIPTION
Fixes #21

## Summary
- add reusable batch reporting module with match/mismatch/missing/error status
- expose new `hash-checker batch` CLI for JSON/CSV inputs and structured report exports
- document workflow in README/docs and add regression tests

## Testing
- cargo fmt --manifest-path rust/hash-checker/Cargo.toml
- cargo test --manifest-path rust/hash-checker/Cargo.toml