### PR TITLE
Docs: refresh roadmap and dependency policy

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -135,7 +135,7 @@ xattr -d com.apple.quarantine "/Applications/Hash Checker.app"
 
 ### Local CI Gate
 - Run `make ci-linux-local` before pushing to execute fmt, clippy, tests, and Docker workflows.
-- Monthly maintenance: `make deps-refresh` updates dependencies, runs `cargo audit`/`cargo deny`, and refreshes cached toolchains. Capture logs under `logs/`.
+- Monthly maintenance: `make deps-refresh` updates dependencies, runs `cargo outdated --workspace --exit-code 1 --root-deps-only` (report) plus `cargo audit`/`cargo deny`, and refreshes cached toolchains. Capture logs under `logs/` and link the report in the monthly maintenance ticket.
 - See **CI Modes (2025-10-19)** for the mapping between local checks and GitHub Actions.
 
 ### Documentation Index
@@ -299,7 +299,7 @@ Keep this document with the repo to standardise release expectations.
 
 ## Maintenance Automation
 - Workflow `.github/workflows/cargo-dist-maintenance.yml` runs monthly to verify the latest `cargo-dist` via `cargo install --locked`.
-- Workflow `.github/workflows/deps-refresh.yml` executes `make deps-refresh`, runs `cargo audit`/`cargo deny`, refreshes the toolchain (`rustup update`, `docker pull`, `cargo-packager`), and stores logs in the workflow artefact.
+- Workflow `.github/workflows/deps-refresh.yml` executes `make deps-refresh`, runs `cargo outdated` (report mode) + `cargo audit`/`cargo deny`, refreshes the toolchain (`rustup update`, `docker pull`, `cargo-packager`), and stores logs in the workflow artefact for traceability.
 - Workflow `.github/workflows/vagrant-smoke-reminder.yml` triggers every quarter (and on demand) to open a reminder issue for manual Vagrant smoke testing.
 - If any workflow fails, open an issue, attach the artefact (`cargo-dist-install-log` or `deps-refresh-log`), fix the pipeline, and update maintenance notes.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -74,6 +74,7 @@
 - Observability & performance:
   - [x] Structured logging/telemetry toggle for CLI runs (added `--log-format`, Oct 2025).
   - [x] Regression benchmarks (criterion) for large files (Oct 2025 benches recorded under `logs/qa/`).
+  - [ ] Automate GUI snapshot harness & telemetry capture (Issue #33).
 - Distribution & automation:
   - [x] Automate reproducible builds (`dist plan`) in CI and capture Debian package install verification.
   - [ ] Add winget/homebrew manifests.
@@ -102,6 +103,7 @@ Progress is tracked via `docs/TASKS.md`, with backlog items in `docs/BACKLOG.md`
 - [ ] Finalise SignPath rollout (secrets, verification docs).
 - [ ] Publish credential/runbook documentation (rotations, emergency).
 - [ ] Maintenance cadence: monthly deps-refresh, quarterly Vagrant smoke.
+- [ ] Formalise dependency refresh policy (cargo outdated/audit reporting in release notes).
 - [ ] Enforce branch protection for release workflows.
 - [ ] Define contributor onboarding (SECURITY.md update, templates).
 ## Release readiness checklist

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -17,8 +17,10 @@ maintained in [`docs/PLAN.md`](PLAN.md); historical summaries live in
 - [x] GTK4/`instant` migration spike (due 2025-11-15): audit GTK3 usage, evaluate alternatives, open tracking issue. (Issue #23)
 - [x] Build GUI manifest deep-tree harness + golden artefacts (see docs/GUI_MANIFEST_TEST_PLAN.md).
 - [x] Adjust manifest table layout + control widths to satisfy GUI_MANIFEST_TEST_PLAN assumptions (A3/A4).
-- [ ] Adopt rfd xdg-portal backend to drop GTK3 dependency (Issue #34).
-- [ ] Upgrade eframe/egui stack to remove `instant` and bump MSRV (Issue #35).
+- [x] Adopt rfd xdg-portal backend to drop GTK3 dependency (Issue #34).
+- [x] Upgrade eframe/egui stack to remove `instant` and bump MSRV (Issue #35).
+- [ ] Automate GUI snapshot harness & telemetry logs (Issue #33).
+- [ ] Formalise dependency refresh workflow (cargo outdated/audit reporting).
 
 ## Deferred / blocked
 - [ ] SignPath onboarding (awaiting OSS credentials and secrets).


### PR DESCRIPTION
## Summary
- add snapshot harness and dependency refresh items to plan/tasks backlog
- document dependency refresh workflow (cargo outdated/audit) in operations guide

## Testing
- none (docs only)
