### PR TITLE
chore: prepare release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 - SignPath signing integration for Windows artefacts.
 - Light-theme palette follow-up adjustments based on tester feedback.
+
+## [0.1.6] - 2025-10-22
 ### Experimental
 - Added optional `gtk4-native` feature (Linux) to begin wiring GTK4 file dialogs behind a feature flag.
+### Changed
+- Documented the GTK4 migration plan and updated CI to smoke test the feature flag on Linux alongside the existing portal flow.
 
 ## [0.1.5] - 2025-10-17
 ### Added


### PR DESCRIPTION
## Summary
- update the changelog with a 0.1.6 entry highlighting the GTK4 feature flag release

## Testing
- gh workflow run ci.yml --ref main --field run_linux=true --field run_macos=true --field run_windows=true --field run_packaging=false (run 18710710100)
- gh workflow run release.yml --ref main (rerun after tagging)
