### PR TITLE
fix: reject conflicting algorithm hints in verification

### DIFF
--- a/rust/hash-checker/src/lib.rs
+++ b/rust/hash-checker/src/lib.rs
@@ -26,6 +26,10 @@ const CHUNK_SIZE: usize = 1024 * 1024;
 pub enum HashError {
     #[error("unsupported algorithm '{0}'")]
     UnsupportedAlgorithm(String),
+    #[error(
+        "conflicting algorithm hints: flag '{provided}' does not match digest prefix '{prefixed}'"
+    )]
+    ConflictingAlgorithmHints { provided: String, prefixed: String },
     #[error("expected hash cannot be empty")]
     EmptyExpectedHash,
     #[error("unable to infer algorithm from digest length {0}")]
@@ -214,6 +218,15 @@ pub fn verify_hash(
         ),
         _ => None,
     };
+
+    if let (Some(provided), Some(prefixed)) = (provided_algorithm, prefix_algorithm) {
+        if provided != prefixed {
+            return Err(HashError::ConflictingAlgorithmHints {
+                provided: provided.to_string(),
+                prefixed: prefixed.to_string(),
+            });
+        }
+    }
 
     let candidates: Vec<&'static str> = if let Some(name) = provided_algorithm {
         vec![name]

--- a/rust/hash-checker/tests/cli_tests.rs
+++ b/rust/hash-checker/tests/cli_tests.rs
@@ -76,6 +76,22 @@ fn cli_infers_blake2b_without_algorithm_flag() {
 }
 
 #[test]
+fn cli_rejects_conflicting_algorithm_hints() {
+    let (temp_dir, path) = sample_file();
+    let digest = compute_hash(path.as_path(), "sha256").expect("hash");
+    let prefixed = format!("sha512:{digest}");
+    let mut cmd = Command::cargo_bin("hash-checker").expect("binary");
+    cmd.arg(&path)
+        .arg(prefixed)
+        .arg("--algorithm")
+        .arg("sha256");
+    cmd.assert()
+        .code(1)
+        .stderr(contains("conflicting algorithm hints"));
+    drop(temp_dir);
+}
+
+#[test]
 fn cli_emits_json_logs_when_requested() {
     let (temp_dir, path) = sample_file();
     let digest = compute_hash(path.as_path(), "sha256").expect("hash");

--- a/rust/hash-checker/tests/hash_tests.rs
+++ b/rust/hash-checker/tests/hash_tests.rs
@@ -104,6 +104,15 @@ fn verify_hash_rejects_unknown_prefix() {
 }
 
 #[test]
+fn verify_hash_rejects_conflicting_algorithm_hints() {
+    let file = write_sample_file();
+    let digest = compute_hash(file.path(), "sha256").expect("hash");
+    let prefixed = format!("sha512:{digest}");
+    let err = verify_hash(file.path(), &prefixed, Some("sha256")).expect_err("expected failure");
+    assert!(matches!(err, HashError::ConflictingAlgorithmHints { .. }));
+}
+
+#[test]
 fn supported_algorithms_contains_expected() {
     let algos = supported_algorithms();
     for name in ["md5", "sha1", "sha256", "blake2b"] {


### PR DESCRIPTION
## Summary
- reject conflicting `--algorithm` and prefixed digest hints before verification
- add library and CLI regressions for the conflict case

## Verification
- `cargo fmt --manifest-path rust/hash-checker/Cargo.toml --check`
- `cargo test --manifest-path rust/hash-checker/Cargo.toml`
- manual repro: conflicting `sha512:` prefix + `--algorithm sha256` now fails instead of returning a false positive

Fixes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hash verification now properly detects and rejects mismatches when the algorithm parameter conflicts with the algorithm specified in the hash digest prefix.

* **Tests**
  * Added unit and integration tests for validating conflicting algorithm hint detection and rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->