### PR TITLE
🧪 Add tests for map_error in batch processing

### DIFF
--- a/rust/hash-checker-gui/Cargo.lock
+++ b/rust/hash-checker-gui/Cargo.lock
@@ -476,9 +476,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cairo-rs"
@@ -2755,9 +2755,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/rust/hash-checker/src/batch.rs
+++ b/rust/hash-checker/src/batch.rs
@@ -247,7 +247,10 @@ mod tests {
         };
         let (status, msg) = map_error(&err);
         assert_eq!(status, BatchStatus::Error);
-        assert_eq!(msg, "failed to canonicalize path 'test.txt': permission denied");
+        assert_eq!(
+            msg,
+            "failed to canonicalize path 'test.txt': permission denied"
+        );
     }
 
     #[test]

--- a/rust/hash-checker/src/batch.rs
+++ b/rust/hash-checker/src/batch.rs
@@ -174,3 +174,106 @@ fn map_error(err: &HashError) -> (BatchStatus, String) {
         _ => (BatchStatus::Error, err.to_string()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn test_map_error_path_not_found() {
+        let err = HashError::PathNotFound("test.txt".to_string());
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Missing);
+        assert_eq!(msg, "path 'test.txt' does not exist");
+    }
+
+    #[test]
+    fn test_map_error_not_a_file() {
+        let err = HashError::NotAFile("test.txt".to_string());
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "path 'test.txt' is not a regular file");
+    }
+
+    #[test]
+    fn test_map_error_unsupported_algorithm() {
+        let err = HashError::UnsupportedAlgorithm("md4".to_string());
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "unsupported algorithm 'md4'");
+    }
+
+    #[test]
+    fn test_map_error_inference_failed() {
+        let err = HashError::InferenceFailed(16);
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "unable to infer algorithm from digest length 16");
+    }
+
+    #[test]
+    fn test_map_error_invalid_expected_hash() {
+        let err = HashError::InvalidExpectedHash;
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "expected hash contains non-hex characters");
+    }
+
+    #[test]
+    fn test_map_error_empty_expected_hash() {
+        let err = HashError::EmptyExpectedHash;
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "expected hash cannot be empty");
+    }
+
+    #[test]
+    fn test_map_error_canonicalize_not_found() {
+        let err = HashError::Canonicalize {
+            path: "test.txt".to_string(),
+            source: io::Error::new(io::ErrorKind::NotFound, "not found"),
+        };
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Missing);
+        assert_eq!(msg, "failed to canonicalize path 'test.txt': not found");
+    }
+
+    #[test]
+    fn test_map_error_canonicalize_other_error() {
+        let err = HashError::Canonicalize {
+            path: "test.txt".to_string(),
+            source: io::Error::new(io::ErrorKind::PermissionDenied, "permission denied"),
+        };
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "failed to canonicalize path 'test.txt': permission denied");
+    }
+
+    #[test]
+    fn test_map_error_io_not_found() {
+        let err = HashError::Io(io::Error::new(io::ErrorKind::NotFound, "not found"));
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Missing);
+        assert_eq!(msg, "not found");
+    }
+
+    #[test]
+    fn test_map_error_io_other_error() {
+        let err = HashError::Io(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "permission denied",
+        ));
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "permission denied");
+    }
+
+    #[test]
+    fn test_map_error_fallback() {
+        let err = HashError::NotADirectory("test.txt".to_string());
+        let (status, msg) = map_error(&err);
+        assert_eq!(status, BatchStatus::Error);
+        assert_eq!(msg, "path 'test.txt' is not a directory");
+    }
+}


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap by adding unit tests for the `map_error` function in `rust/hash-checker/src/batch.rs`.

📊 **Coverage:** The new tests cover all branches and variants evaluated by `map_error`, including:
- `PathNotFound`
- `NotAFile`
- `UnsupportedAlgorithm`
- `InferenceFailed`
- `InvalidExpectedHash`
- `EmptyExpectedHash`
- `Canonicalize` (both `NotFound` and other I/O errors)
- `Io` (both `NotFound` and other I/O errors)
- The fallback (`_`) branch

✨ **Result:** Test coverage for the batch module is significantly improved, catching potential regressions in error mapping behavior.

---
*PR created automatically by Jules for task [3161822270164981983](https://jules.google.com/task/3161822270164981983) started by @tamld*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for error handling in hash verification workflows, improving test coverage across various failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->